### PR TITLE
style: fix sub-caret size

### DIFF
--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -241,6 +241,7 @@ body nav[class*="navbarHidden"] {
   color: var(--ifm-color-primary);
 }
 
+.menu__caret:before,
 .menu__link--sublist-caret:after {
   background: var(--ifm-menu-link-sublist-icon) 50% / 1.28rem 1.28rem;
 }


### PR DESCRIPTION
This PR makes the dropdown arrows between normal pages and idex pages consistent.