### PR TITLE
chore: dockerize

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,71 @@
+name: docker
+
+on:
+    push:
+        branches:
+            - "main"
+        tags:
+            - "v*"
+
+jobs:
+    docker-dev:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+
+            - name: Login to GitHub Container Registry
+              uses: docker/login-action@v2
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.repository_owner }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Docker meta
+              id: meta
+              uses: docker/metadata-action@v4
+              with:
+                  images: ghcr.io/${{ github.repository }}
+                  tags: |
+                      type=raw,value=dev
+                      type=semver,pattern=v{{version}}-dev
+
+            - name: Build and push
+              uses: docker/build-push-action@v3
+              with:
+                  context: .
+                  file: "./Dockerfile"
+                  push: ${{ github.event_name != 'pull_request' }}
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: ${{ steps.meta.outputs.labels }}
+
+    docker-production:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+
+            - name: Login to GitHub Container Registry
+              uses: docker/login-action@v2
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.repository_owner }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Docker meta
+              id: meta
+              uses: docker/metadata-action@v4
+              with:
+                  images: ghcr.io/${{ github.repository }}
+                  tags: |
+                      type=raw,value=latest
+                      type=semver,pattern=v{{version}}
+
+            - name: Build and push
+              uses: docker/build-push-action@v3
+              with:
+                  context: .
+                  file: "./Dockerfile.production"
+                  push: ${{ github.event_name != 'pull_request' }}
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -6,11 +6,6 @@ on:
     branches:
       - main
 
-env:
-  MEILISEARCH_URL: ${{ secrets.MEILISEARCH_URL }}
-  MEILISEARCH_API_KEY: ${{ secrets.MEILISEARCH_API_KEY }}
-  MEILISEARCH_INDEX_UID: ${{ secrets.MEILISEARCH_INDEX_UID}}
-
 jobs:
   deploy-netlify:
     name: deploy-to-netlify

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /app
 
 COPY . .
 
+RUN rm -rf build docs
+
 WORKDIR /app/docusaurus
 
 RUN yarn install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:18.18.0-alpine3.18 as build
+
+WORKDIR /app
+
+COPY . .
+
+WORKDIR /app/docusaurus
+
+RUN yarn install
+
+CMD [ "yarn", "start", "--host=0.0.0.0" ]

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,0 +1,14 @@
+FROM node:18.18.0-alpine3.18 as build
+
+WORKDIR /app
+
+COPY . .
+
+WORKDIR /app/docusaurus
+
+RUN yarn install
+RUN yarn build
+
+FROM nginx:stable-alpine
+
+COPY --from=build /app/docusaurus/build /usr/share/nginx/html/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,8 @@
 version: "3"
 
-# gnolang/docs.gno.land
 services:
   docusaurus:
-    image: ghcr.io/gnolang/docs.gno.land:latest-dev
+    image: ghcr.io/gnolang/docs.gno.land:dev
     build:
       context: .
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3"
+
+# gnolang/docs.gno.land
+services:
+  docusaurus:
+    image: ghcr.io/gnolang/docs.gno.land:latest-dev
+    build:
+      context: .
+    volumes:
+      - .:/app/docs
+    ports:
+      - 3000:3000
+    environment:
+      - MEILISEARCH_URL="localhost:7700"
+      - MEILISEARCH_API_KEY="masterKey"
+      - MEILISEARCH_INDEX_UID="dev"
+
+  meilisearch:
+    image: getmeili/meilisearch
+    restart: unless-stopped
+    environment:
+      - MEILI_MASTER_KEY=masterKey
+      - MEILI_NO_ANALYTICS=true
+      - MEILI_ENV=dev
+      - MEILI_LOG_LEVEL=info
+      - MEILI_DB_PATH=/data.ms
+    ports:
+      - 7700:7700
+    #volumes:
+    #  - ./data.ms:/data.ms


### PR DESCRIPTION
This PR will create 2 docker images on every build.

1. a `dev` version with docker tag `dev`.
You'll use this version for running the website locally with the docs in volume in the repo gnolang/gno (pr for this is comming)

2. a `production` version, more classic that contain the website with the docs at current version.