### PR TITLE
feat: add creating-dao guide in sidebar

### DIFF
--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -34,6 +34,7 @@ const sidebars = {
                 'how-to-guides/deploy',
                 'how-to-guides/write-simple-dapp',
                 'how-to-guides/creating-grc20',
+                'how-to-guides/creating-dao',
                 'how-to-guides/connect-from-go',
                 'how-to-guides/connect-wallet-dapp',
             ],


### PR DESCRIPTION
Depends on https://github.com/gnolang/gno/pull/1925

This adds the dao guide in sidebar