### PR TITLE
chore(netlify): enforce variables in netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,11 @@ publish = "build"
 
 command = "yarn run download-docs && yarn build && yarn install"
 
+[context.production.environment]
+MEILISEARCH_URL = "https://docs-search.gnoteam.com"
+MEILISEARCH_INDEX_UID = "production"
+MEILISEARCH_API_KEY = "22a22f25327d4bff5be707fa7ee90a731e6b6c8c5a6f13c705dafcce642caafd"
+
 [[plugins]]
 package = "@netlify/plugin-lighthouse"
 


### PR DESCRIPTION
`MEILISEARCH_API_KEY` isn't a secret.