### PR TITLE
feat: Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# CODEOWNERS: https://help.github.com/articles/about-codeowners/
+
+# Primary repo maintainers.
+*                             @gnolang/tech-staff

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,7 @@
 # CODEOWNERS: https://help.github.com/articles/about-codeowners/
 
 # Primary repo maintainers.
-*                             @gnolang/tech-staff
+*                   @gnolang/tech-staff
+
+# Docusaurus
+/docusaurus/        @alexiscolin


### PR DESCRIPTION
Current state

- No code owners for docs.gno.land - open PRs aren't automatically assigning reviewers

Desired state

- Tech staff team are code owners. Open PRs automatically assign reviewers

AC

- Add @gnolang/tech-staff as docs.gno.land code owners