### PR TITLE
docusaurus: replace gnoclient docs with godoc

### DIFF
--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -165,10 +165,7 @@ const sidebars = {
                     type: 'category',
                     label: 'gnoclient',
                     link: {type: 'doc', id: 'reference/gnoclient/gnoclient'},
-                    items: [
-                        'reference/gnoclient/signer',
-                        'reference/gnoclient/client'
-                    ]
+                    items: []
                 },
             ],
         },


### PR DESCRIPTION
## Description

I've replaced the current gnoclient docs with a godoc page that we have. This will make maintaining these docs much more simple. 

Paired with https://github.com/gnolang/gno/pull/2404 & https://github.com/gnolang/gno/pull/2416