### PR TITLE
fixing api key in netlify ci job

### DIFF
--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -30,7 +30,7 @@ jobs:
       env:
         MEILISEARCH_URL: "https://docs-search.gnoteam.com"
         MEILISEARCH_INDEX_UID: "production"
-        MEILISEARCH_API_KEY: "22a22f25327d4bff5be707fa7ee90a731e6b6c8c5a6f13c705dafcce642caafd"
+        MEILISEARCH_API_KEY: "6d7b970053413ade30e07212c7d36c7cdea3f47ede2e63e1147317f8718e65e1"
 
     - name: Deploy to netlify
       uses: netlify/actions/cli@master


### PR DESCRIPTION
Fixing key mismatch between:

* .github/workflows/netlify.yml
* netlify.toml