### PR TITLE
chore (fix): solving issues with netlify auto-deploy

### DIFF
--- a/.github/workflows/meilisearch.yml
+++ b/.github/workflows/meilisearch.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   indexing:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     name: Meilisearch Indexing
     steps:

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -37,9 +37,9 @@ jobs:
         MEILISEARCH_INDEX_UID: "production"
 
     - name: Deploy to netlify
-      uses: netlify/actions/cli@master
-      with:
-        args: deploy --site gno-docs --prod
+      run: |
+        npm install -g netlify-cli
+        netlify deploy --prod --debug
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}


### PR DESCRIPTION
- replacing `netlify-cli` action with native Node js netlify cli library
- re-hauling the deploy using now NETLIFY_SITE_ID secret
- meilisearch job now runs only if build/deploy job is successful