### PR TITLE
fix: update markdown parsing configuration in docusaurus config

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -18,6 +18,13 @@ const config = {
   onBrokenLinks: "warn",
   onBrokenMarkdownLinks: "warn",
 
+  // Parse `.md` files as CommonMark (only `.mdx` uses MDX). This makes the
+  // monorepo docs immune to MDX parsing errors from literal `{...}` / `<...>`
+  // in prose (e.g. CONSTITUTION.md), which previously broke the production build.
+  markdown: {
+    format: "detect",
+  },
+
   i18n: {
     defaultLocale: "en",
     locales: ["en"],


### PR DESCRIPTION
The production build has been failing since ~Aug 2025 (site frozen ~9 months): Docusaurus parses `.md` as MDX, and literal `{...}` in prose (e.g. `docs/CONSTITUTION.md`) breaks the build with "Could not parse expression with acorn".

This sets `markdown.format: "detect"` so `.md` is parsed as CommonMark (`.mdx` stays MDX), fixing the whole class of error at once. Safe: all docs are `.md` with no MDX features, and admonitions (`:::`) + `remarkTabbedCodeBlock` still work.