### PR TITLE
Add 301 redirects for builder doc paths changed in gno#5656

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -23,46 +23,45 @@ package = "@netlify/plugin-lighthouse"
 # These old URLs are indexed and linked externally, so they 301 to their
 # new homes instead of 404ing. Update or extend when docs paths move again.
 
+# The `to` paths carry a trailing slash because the site canonicalizes to one
+# (e.g. /builders/getting-started 301s to /builders/getting-started/); matching
+# it here keeps each redirect a single hop instead of chaining two 301s.
+
 # Deleted pages, content folded into other guides.
 [[redirects]]
   from = "/builders/anatomy-of-a-gno-package"
-  to = "/builders/getting-started"
+  to = "/builders/getting-started/"
   status = 301
 
 [[redirects]]
   from = "/builders/deploy-packages"
-  to = "/builders/getting-started"
+  to = "/builders/getting-started/"
   status = 301
 
 [[redirects]]
   from = "/builders/local-dev-with-gnodev"
-  to = "/resources/gnodev"
+  to = "/resources/gnodev/"
   status = 301
 
 # Renamed pages.
 [[redirects]]
   from = "/builders/what-is-gnolang"
-  to = "/builders/what-is-gno"
-  status = 301
-
-[[redirects]]
-  from = "/builders/quick-start"
-  to = "/builders/quickstart"
+  to = "/builders/what-is-gno/"
   status = 301
 
 [[redirects]]
   from = "/builders/connect-clients-and-apps"
-  to = "/builders/rpc-clients"
+  to = "/builders/rpc-clients/"
   status = 301
 
 [[redirects]]
   from = "/builders/become-a-gnome"
-  to = "/builders/contributor-guide"
+  to = "/builders/contributor-guide/"
   status = 301
 
 [[redirects]]
   from = "/builders/example-minisocial-dapp"
-  to = "/builders/tutorial-minisocial"
+  to = "/builders/tutorial-minisocial/"
   status = 301
 
 # [[headers]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -19,6 +19,52 @@ NODE_VERSION = "20.18"
 [[plugins]]
 package = "@netlify/plugin-lighthouse"
 
+# Redirects for builder docs paths that changed in gnolang/gno#5656.
+# These old URLs are indexed and linked externally, so they 301 to their
+# new homes instead of 404ing. Update or extend when docs paths move again.
+
+# Deleted pages, content folded into other guides.
+[[redirects]]
+  from = "/builders/anatomy-of-a-gno-package"
+  to = "/builders/getting-started"
+  status = 301
+
+[[redirects]]
+  from = "/builders/deploy-packages"
+  to = "/builders/getting-started"
+  status = 301
+
+[[redirects]]
+  from = "/builders/local-dev-with-gnodev"
+  to = "/resources/gnodev"
+  status = 301
+
+# Renamed pages.
+[[redirects]]
+  from = "/builders/what-is-gnolang"
+  to = "/builders/what-is-gno"
+  status = 301
+
+[[redirects]]
+  from = "/builders/quick-start"
+  to = "/builders/quickstart"
+  status = 301
+
+[[redirects]]
+  from = "/builders/connect-clients-and-apps"
+  to = "/builders/rpc-clients"
+  status = 301
+
+[[redirects]]
+  from = "/builders/become-a-gnome"
+  to = "/builders/contributor-guide"
+  status = 301
+
+[[redirects]]
+  from = "/builders/example-minisocial-dapp"
+  to = "/builders/tutorial-minisocial"
+  status = 301
+
 # [[headers]]
 #   # Define which paths this specific [[headers]] block will cover.
 #   for = "/*"


### PR DESCRIPTION
The builder docs consolidation in gnolang/gno#5656 deletes three pages and renames five more. The deleted pages are anatomy-of-a-gno-package, deploy-packages, and local-dev-with-gnodev. Their old URLs are indexed and linked externally, so they will 404 once #5656 merges.

This adds Netlify 301 redirects in netlify.toml that send each old path to its new home, so external links keep working and search ranking carries over. It pairs with gnolang/gno#5656: the deletion targets already exist today and the rename targets land with that PR, so it is safe to merge alongside it.

Raised from @alexiscolin's review feedback on gnolang/gno#5656.