### PR TITLE
fix: link out of the docs folder to the monorepo on GitHub

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -83,10 +83,10 @@ const config = {
           showLastUpdateTime: true,
           editUrl: ({ docPath }) => `${repoURL}/edit/${repoRef}/docs/${docPath}`,
           sidebarCollapsed: false,
-          remarkPlugins: [
-            remarkTabbedCodeBlock,
+          beforeDefaultRemarkPlugins: [
             [remarkExternalRepoLinks, { docsDir, repoURL, repoRef }],
           ],
+          remarkPlugins: [remarkTabbedCodeBlock],
         },
         blog: false,
         theme: {

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -13,7 +13,6 @@ const remarkExternalRepoLinks = require("./src/remark/external-repo-links");
 const repo = "gnolang/gno";
 const repoRef = "master";
 const repoURL = `https://github.com/${repo}`;
-const rawURL = `https://raw.githubusercontent.com/${repo}`;
 const docsPath = "docs";
 const docsDir = path.resolve(__dirname, "..", docsPath);
 
@@ -87,7 +86,7 @@ const config = {
           editUrl: ({ docPath }) => `${repoURL}/edit/${repoRef}/${docsPath}/${docPath}`,
           sidebarCollapsed: false,
           beforeDefaultRemarkPlugins: [
-            [remarkExternalRepoLinks, { docsDir, docsPath, repoURL, rawURL, repoRef }],
+            [remarkExternalRepoLinks, { docsDir, docsPath, repoURL, repoRef }],
           ],
           remarkPlugins: [remarkTabbedCodeBlock],
         },

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -14,7 +14,8 @@ const repo = "gnolang/gno";
 const repoRef = "master";
 const repoURL = `https://github.com/${repo}`;
 const rawURL = `https://raw.githubusercontent.com/${repo}`;
-const docsDir = path.resolve(__dirname, "../docs");
+const docsPath = "docs";
+const docsDir = path.resolve(__dirname, "..", docsPath);
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -83,10 +84,10 @@ const config = {
           routeBasePath: "/",
           sidebarPath: require.resolve("./sidebars.js"),
           showLastUpdateTime: true,
-          editUrl: ({ docPath }) => `${repoURL}/edit/${repoRef}/docs/${docPath}`,
+          editUrl: ({ docPath }) => `${repoURL}/edit/${repoRef}/${docsPath}/${docPath}`,
           sidebarCollapsed: false,
           beforeDefaultRemarkPlugins: [
-            [remarkExternalRepoLinks, { docsDir, repoURL, rawURL, repoRef }],
+            [remarkExternalRepoLinks, { docsDir, docsPath, repoURL, rawURL, repoRef }],
           ],
           remarkPlugins: [remarkTabbedCodeBlock],
         },

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -10,8 +10,10 @@ const remarkExternalRepoLinks = require("./src/remark/external-repo-links");
 
 // Where the docs come from: scripts/download-docs.sh downloads this branch of
 // this repository and puts its docs folder here
-const repoURL = "https://github.com/gnolang/gno";
+const repo = "gnolang/gno";
 const repoRef = "master";
+const repoURL = `https://github.com/${repo}`;
+const rawURL = `https://raw.githubusercontent.com/${repo}`;
 const docsDir = path.resolve(__dirname, "../docs");
 
 /** @type {import('@docusaurus/types').Config} */
@@ -84,7 +86,7 @@ const config = {
           editUrl: ({ docPath }) => `${repoURL}/edit/${repoRef}/docs/${docPath}`,
           sidebarCollapsed: false,
           beforeDefaultRemarkPlugins: [
-            [remarkExternalRepoLinks, { docsDir, repoURL, repoRef }],
+            [remarkExternalRepoLinks, { docsDir, repoURL, rawURL, repoRef }],
           ],
           remarkPlugins: [remarkTabbedCodeBlock],
         },

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -8,8 +8,10 @@ const darkCodeTheme = require("prism-react-renderer").themes.jettwaveDark;
 const remarkTabbedCodeBlock = require("./src/remark/tabbed-code-block");
 const remarkExternalRepoLinks = require("./src/remark/external-repo-links");
 
-// The folder scripts/download-docs.sh puts the monorepo docs in, shared by the
-// docs preset and by the plugin that rewrites the links leaving it
+// Where the docs come from: scripts/download-docs.sh downloads this branch of
+// this repository and puts its docs folder here
+const repoURL = "https://github.com/gnolang/gno";
+const repoRef = "master";
 const docsDir = path.resolve(__dirname, "../docs");
 
 /** @type {import('@docusaurus/types').Config} */
@@ -79,12 +81,11 @@ const config = {
           routeBasePath: "/",
           sidebarPath: require.resolve("./sidebars.js"),
           showLastUpdateTime: true,
-          editUrl: ({ docPath }) =>
-            `https://github.com/gnolang/gno/edit/master/docs/${docPath}`,
+          editUrl: ({ docPath }) => `${repoURL}/edit/${repoRef}/docs/${docPath}`,
           sidebarCollapsed: false,
           remarkPlugins: [
             remarkTabbedCodeBlock,
-            [remarkExternalRepoLinks, { docsDir }],
+            [remarkExternalRepoLinks, { docsDir, repoURL, repoRef }],
           ],
         },
         blog: false,

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -1,9 +1,16 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 
+const path = require("node:path");
+
 const lightCodeTheme = require("prism-react-renderer").themes.jettwaveLight;
 const darkCodeTheme = require("prism-react-renderer").themes.jettwaveDark;
 const remarkTabbedCodeBlock = require("./src/remark/tabbed-code-block");
+const remarkExternalRepoLinks = require("./src/remark/external-repo-links");
+
+// The folder scripts/download-docs.sh puts the monorepo docs in, shared by the
+// docs preset and by the plugin that rewrites the links leaving it
+const docsDir = path.resolve(__dirname, "../docs");
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -68,14 +75,17 @@ const config = {
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
         docs: {
-          path: "../docs",
+          path: docsDir,
           routeBasePath: "/",
           sidebarPath: require.resolve("./sidebars.js"),
           showLastUpdateTime: true,
           editUrl: ({ docPath }) =>
             `https://github.com/gnolang/gno/edit/master/docs/${docPath}`,
           sidebarCollapsed: false,
-          remarkPlugins: [remarkTabbedCodeBlock],
+          remarkPlugins: [
+            remarkTabbedCodeBlock,
+            [remarkExternalRepoLinks, { docsDir }],
+          ],
         },
         blog: false,
         theme: {

--- a/docusaurus/src/remark/external-repo-links.js
+++ b/docusaurus/src/remark/external-repo-links.js
@@ -1,31 +1,25 @@
 import path from "node:path";
 import { visit } from "unist-util-visit";
 
-// The docs folder is the only part of the monorepo this site holds:
-// scripts/download-docs.sh keeps gno-master/docs and drops the rest. A link
-// climbing out of it therefore has no page to point at, and Docusaurus emits it
-// verbatim, so `../../examples/gno.land/p/nt/avl/v0` ships as
-// `/examples/gno.land/p/nt/avl/v0` and returns 404. Those targets are real
-// files in the monorepo, so the link becomes a URL to the monorepo instead.
-const repoURL = "https://github.com/gnolang/gno";
-
-// The branch download-docs.sh pulls the docs from
-const repoRef = "master";
-
 /**
  * Rewrites every relative link that resolves outside the docs folder into an
  * absolute GitHub URL, leaving the markdown sources relative.
  *
- * The source file keeps `[avl](../../examples/gno.land/p/nt/avl/v0)`, which
- * resolves in the monorepo and on GitHub. The built page carries
- * `https://github.com/gnolang/gno/tree/master/examples/gno.land/p/nt/avl/v0`.
+ * The docs folder is the only part of the monorepo this site holds, so a link
+ * climbing out of it has no page to point at and Docusaurus emits it verbatim:
+ * `../../examples/gno.land/p/nt/avl/v0` ships as
+ * `/examples/gno.land/p/nt/avl/v0` and returns 404. The target is a real file
+ * in the monorepo, so the built page points there instead, at
+ * `https://github.com/gnolang/gno/tree/master/examples/gno.land/p/nt/avl/v0`,
+ * while the markdown keeps the relative link that resolves in a checkout.
  *
- * @param {{docsDir: string}} options docsDir is the folder Docusaurus reads the
- * docs from, matching the `path` of the docs preset.
+ * @param {{docsDir: string, repoURL: string, repoRef: string}} options docsDir
+ * matches the `path` of the docs preset, and repoURL and repoRef name the
+ * repository and branch the docs were downloaded from.
  */
-export default function externalRepoLinks({ docsDir } = {}) {
-  if (!docsDir) {
-    throw new Error("external-repo-links: docsDir is required, and must match the docs preset path");
+export default function externalRepoLinks({ docsDir, repoURL, repoRef } = {}) {
+  if (!docsDir || !repoURL || !repoRef) {
+    throw new Error("external-repo-links: docsDir, repoURL and repoRef are all required");
   }
 
   const docsRoot = path.resolve(docsDir);
@@ -36,17 +30,19 @@ export default function externalRepoLinks({ docsDir } = {}) {
     const fileDir = path.dirname(path.resolve(file.path));
 
     visit(tree, ["link", "definition"], (node) => {
-      const url = externalRepoURL(node.url, fileDir, docsRoot);
-      if (url) node.url = url;
+      const repoPath = externalRepoPath(node.url, fileDir, docsRoot, repoRef);
+      if (!repoPath) return;
+
+      node.url = `${repoURL}/${repoPath}`;
     });
   };
 }
 
 /**
- * Returns the GitHub URL for a link that leaves the docs folder, or null for
- * one the site can resolve on its own.
+ * Returns the `<kind>/<ref>/<path>` a link leaving the docs folder addresses in
+ * the monorepo, or null for one the site can resolve on its own.
  */
-function externalRepoURL(url, fileDir, docsDir) {
+function externalRepoPath(url, fileDir, docsDir, repoRef) {
   if (!url || !isRelative(url)) return null;
 
   const [target, suffix] = splitTarget(url);
@@ -66,7 +62,7 @@ function externalRepoURL(url, fileDir, docsDir) {
   // but /blob/ is the URL a reader recognises.
   const kind = path.extname(repoPath) ? "blob" : "tree";
 
-  return `${repoURL}/${kind}/${repoRef}/${repoPath}${suffix}`;
+  return `${kind}/${repoRef}/${repoPath}${suffix}`;
 }
 
 // A link is relative when it addresses a path from the file holding it: not a

--- a/docusaurus/src/remark/external-repo-links.js
+++ b/docusaurus/src/remark/external-repo-links.js
@@ -1,6 +1,11 @@
 import path from "node:path";
 import { visit } from "unist-util-visit";
 
+// One URL-carrying attribute of a raw HTML tag, `href="../x"` or `src='../x'`.
+// The captures are the attribute name, the opening quote, and the URL up to the
+// same quote closing it.
+const HTML_URL = /\b(href|src)=("|')(.*?)\2/g;
+
 /**
  * Rewrites every relative link that resolves outside the docs folder into an
  * absolute GitHub URL, leaving the markdown sources relative.
@@ -8,32 +13,27 @@ import { visit } from "unist-util-visit";
  * The docs folder is the only part of the monorepo this site holds, so a link
  * climbing out of it has no page to point at and Docusaurus emits it verbatim:
  * `../../examples/gno.land/p/nt/avl/v0` ships as
- * `/examples/gno.land/p/nt/avl/v0` and returns 404. The target is a real file
- * in the monorepo, so the built page points there instead, at
- * `https://github.com/gnolang/gno/tree/master/examples/gno.land/p/nt/avl/v0`,
- * while the markdown keeps the relative link that resolves in a checkout.
+ * `/examples/gno.land/p/nt/avl/v0` and returns 404. The built page points at
+ * the monorepo instead, while the markdown keeps the relative link that
+ * resolves in a checkout.
  *
- * An image needs the file itself rather than the page around it, so it goes to
- * raw.githubusercontent.com. A `/blob/` URL answers with HTML and renders as a
- * broken image.
+ * An image goes to `rawURL`, everything else to `repoURL`, because a blob URL
+ * answers with HTML and renders as a broken image.
  *
- * Register the plugin under `beforeDefaultRemarkPlugins`. Docusaurus resolves
- * markdown links and reads images from disk before anything in `remarkPlugins`,
- * so registered there it inherits a warning on every link it is about to fix
- * and never sees an image at all: the build fails first on `Image ... not
- * found`.
+ * Register under `beforeDefaultRemarkPlugins`. Docusaurus resolves markdown
+ * links and reads images off disk ahead of `remarkPlugins`, so a plugin
+ * registered there runs too late to do either job.
  *
- * @param {{docsDir: string, repoURL: string, repoRef: string}} options docsDir
- * matches the `path` of the docs preset, and repoURL and repoRef name the
+ * @param {{docsDir: string, repoURL: string, rawURL: string, repoRef: string}}
+ * options docsDir matches the `path` of the docs preset, and the rest name the
  * repository and branch the docs were downloaded from.
  */
-export default function externalRepoLinks({ docsDir, repoURL, repoRef } = {}) {
-  if (!docsDir || !repoURL || !repoRef) {
-    throw new Error("external-repo-links: docsDir, repoURL and repoRef are all required");
+export default function externalRepoLinks({ docsDir, repoURL, rawURL, repoRef } = {}) {
+  if (!docsDir || !repoURL || !rawURL || !repoRef) {
+    throw new Error("external-repo-links: docsDir, repoURL, rawURL and repoRef are all required");
   }
 
   const docsRoot = path.resolve(docsDir);
-  const rawURL = repoURL.replace("https://github.com/", "https://raw.githubusercontent.com/");
 
   return (tree, file) => {
     if (!file.path) return;
@@ -45,77 +45,48 @@ export default function externalRepoLinks({ docsDir, repoURL, repoRef } = {}) {
     const imageIdentifiers = new Set();
     visit(tree, "imageReference", (node) => imageIdentifiers.add(node.identifier));
 
-    const target = (url, isAsset) => {
-      const repoPath = externalRepoPath(url, fileDir, docsRoot);
-      if (!repoPath) return null;
+    const urlFor = (url, isImage) => {
+      if (!url) return null;
 
-      return isAsset
-        ? `${rawURL}/${repoRef}/${repoPath}`
-        : `${repoURL}/${kindOf(repoPath)}/${repoRef}/${repoPath}`;
+      // The path the link addresses, then the ?query#fragment that rides on the
+      // URL built from it.
+      const [, target, suffix] = url.match(/^([^?#]*)(.*)$/);
+
+      // Only a path relative to the file holding it can leave the docs folder.
+      if (!target || /^([a-z][a-z0-9+.-]*:|\/\/|\/)/i.test(target)) return null;
+
+      const [up, ...rest] = path.relative(docsRoot, path.resolve(fileDir, target)).split(path.sep);
+
+      // In the monorepo the docs folder sits at the repository root, so a link
+      // climbing one level above it is addressed from that root. One climbing
+      // two levels leaves the repository and has no URL to build.
+      if (up !== ".." || !rest.length || rest[0] === "..") return null;
+
+      const repoPath = rest.join("/");
+      if (isImage) return `${rawURL}/${repoRef}/${repoPath}${suffix}`;
+
+      // A path carrying an extension is a file. GitHub serves both under
+      // /tree/, but /blob/ is the URL a reader recognises.
+      const kind = path.extname(repoPath) ? "blob" : "tree";
+
+      return `${repoURL}/${kind}/${repoRef}/${repoPath}${suffix}`;
     };
 
     visit(tree, ["link", "image", "definition", "html"], (node) => {
       // Raw HTML reaches the page as written, so the attributes are rewritten
       // in the string itself.
       if (node.type === "html") {
-        node.value = node.value.replace(
-          /\b(href|src)=("|')(.*?)\2/g,
-          (attribute, name, quote, url) => {
-            const rewritten = target(url, name === "src");
+        node.value = node.value.replace(HTML_URL, (attribute, name, quote, url) => {
+          const rewritten = urlFor(url, name === "src");
 
-            return rewritten ? `${name}=${quote}${rewritten}${quote}` : attribute;
-          },
-        );
+          return rewritten ? `${name}=${quote}${rewritten}${quote}` : attribute;
+        });
 
         return;
       }
 
-      const isAsset = node.type === "image" || imageIdentifiers.has(node.identifier);
-      const rewritten = target(node.url, isAsset);
+      const rewritten = urlFor(node.url, node.type === "image" || imageIdentifiers.has(node.identifier));
       if (rewritten) node.url = rewritten;
     });
   };
-}
-
-/**
- * Returns the `<path>?<query>#<fragment>` a link leaving the docs folder
- * addresses in the monorepo, or null for one the site can resolve on its own.
- */
-function externalRepoPath(url, fileDir, docsDir) {
-  if (!url || !isRelative(url)) return null;
-
-  const [target, suffix] = splitTarget(url);
-  if (!target) return null;
-
-  const segments = path.relative(docsDir, path.resolve(fileDir, target)).split(path.sep);
-
-  // In the monorepo the docs folder sits at the repository root, so a link
-  // climbing one level above it is addressed from that root. One climbing two
-  // levels leaves the repository and has no URL to build.
-  if (segments[0] !== ".." || segments[1] === "..") return null;
-
-  const repoPath = segments.slice(1).join("/");
-  if (!repoPath) return null;
-
-  return `${repoPath}${suffix}`;
-}
-
-// A path carrying an extension is a file. GitHub serves both under /tree/, but
-// /blob/ is the URL a reader recognises.
-function kindOf(repoPath) {
-  return path.extname(repoPath.replace(/[?#].*$/, "")) ? "blob" : "tree";
-}
-
-// A link is relative when it addresses a path from the file holding it: not a
-// URL, not a protocol-relative or site-absolute path, not a bare fragment.
-function isRelative(url) {
-  return !/^([a-z][a-z0-9+.-]*:|\/\/|\/|#)/i.test(url);
-}
-
-// Splits a link into the path it addresses and the ?query#fragment that rides
-// on the URL built from it
-function splitTarget(url) {
-  const start = url.search(/[?#]/);
-
-  return start === -1 ? [url, ""] : [url.slice(0, start), url.slice(start)];
 }

--- a/docusaurus/src/remark/external-repo-links.js
+++ b/docusaurus/src/remark/external-repo-links.js
@@ -13,13 +13,14 @@ const HTML_URL = /\b(href|src)=("|')(.*?)\2/g;
  *
  * Register under `beforeDefaultRemarkPlugins`.
  *
- * @param {{docsDir: string, repoURL: string, rawURL: string, repoRef: string}}
- * options docsDir matches the `path` of the docs preset, and the rest name the
+ * @param {{docsDir: string, docsPath: string, repoURL: string, rawURL: string,
+ * repoRef: string}} options docsDir matches the `path` of the docs preset,
+ * docsPath is where that folder sits in the repository, and the rest name the
  * repository and branch the docs were downloaded from.
  */
-export default function externalRepoLinks({ docsDir, repoURL, rawURL, repoRef } = {}) {
-  if (!docsDir || !repoURL || !rawURL || !repoRef) {
-    throw new Error("external-repo-links: docsDir, repoURL, rawURL and repoRef are all required");
+export default function externalRepoLinks({ docsDir, docsPath, repoURL, rawURL, repoRef } = {}) {
+  if (!docsDir || !docsPath || !repoURL || !rawURL || !repoRef) {
+    throw new Error("external-repo-links: every option is required");
   }
 
   const docsRoot = path.resolve(docsDir);
@@ -40,15 +41,17 @@ export default function externalRepoLinks({ docsDir, repoURL, rawURL, repoRef } 
       const [, target, suffix] = url.match(/^([^?#]*)(.*)$/);
 
       // Relative paths only.
-      if (!target || /^([a-z][a-z0-9+.-]*:|\/\/|\/)/i.test(target)) return null;
+      if (!target || /^([a-z][a-z0-9+.-]*:|\/)/i.test(target)) return null;
 
-      const [up, ...rest] = path.relative(docsRoot, path.resolve(fileDir, target)).split(path.sep);
+      const fromDocs = path.relative(docsRoot, path.resolve(fileDir, target)).split(path.sep).join("/");
 
-      // One level above the docs folder is the repository root, two is outside
-      // the repository.
-      if (up !== ".." || !rest.length || rest[0] === "..") return null;
+      // Inside the docs folder the site resolves the link itself.
+      if (!fromDocs.startsWith("../")) return null;
 
-      const repoPath = rest.join("/");
+      // Above the repository root nothing can be addressed.
+      const repoPath = path.posix.join(docsPath, fromDocs);
+      if (repoPath.startsWith("../")) return null;
+
       if (isImage) return `${rawURL}/${repoRef}/${repoPath}${suffix}`;
 
       // A path carrying an extension is a file.
@@ -69,7 +72,11 @@ export default function externalRepoLinks({ docsDir, repoURL, rawURL, repoRef } 
         return;
       }
 
-      const rewritten = urlFor(node.url, node.type === "image" || imageIdentifiers.has(node.identifier));
+      const isImage =
+        node.type === "image" ||
+        (node.type === "definition" && imageIdentifiers.has(node.identifier));
+
+      const rewritten = urlFor(node.url, isImage);
       if (rewritten) node.url = rewritten;
     });
   };

--- a/docusaurus/src/remark/external-repo-links.js
+++ b/docusaurus/src/remark/external-repo-links.js
@@ -4,7 +4,7 @@ import { visit } from "unist-util-visit";
 // Splits a URL: `../x.md?plain=1#L3` -> `../x.md` + `?plain=1#L3`
 const URL_PARTS = /^([^?#]*)(.*)$/;
 
-// Matches a URL that does not start from this file: `https://x`, `mailto:x`, `/x`
+// Matches a URL that is not relative: `https://x`, `mailto:x`, `/x`
 const ABSOLUTE = /^([a-z][a-z0-9+.-]*:|\/)/i;
 
 // Matches one URL attribute of an HTML tag: `href="../x"`, `src='../x'`
@@ -36,7 +36,6 @@ export default function externalRepoLinks({ docsDir, docsPath, repoURL, rawURL, 
 
     const fileDir = path.dirname(path.resolve(file.path));
 
-    // Definitions an image reads: `![alt][logo]` + `[logo]: ../x.png` -> `logo`
     const imageIdentifiers = new Set();
     visit(tree, "imageReference", (node) => imageIdentifiers.add(node.identifier));
 
@@ -46,26 +45,28 @@ export default function externalRepoLinks({ docsDir, docsPath, repoURL, rawURL, 
       const [, target, suffix] = url.match(URL_PARTS);
       if (!target || ABSOLUTE.test(target)) return null;
 
-      // in `docs/resources/a.md`, `../../misc/logo.png` -> `../misc/logo.png`
+      // Target seen from the docs folder: `resources/a.md` + `../../misc/x` -> `../misc/x`
       const fromDocs = path.relative(docsRoot, path.resolve(fileDir, target)).split(path.sep).join("/");
 
-      // no `../`: inside the docs folder, the site resolves it
+      // No `../`: the target is inside the docs folder, the site resolves it
       if (!fromDocs.startsWith("../")) return null;
 
-      // `../misc/logo.png` -> `misc/logo.png`, one more `../` is out of the repository
+      // Same target from the repository root: `../misc/x` -> `misc/x`
       const repoPath = path.posix.join(docsPath, fromDocs);
+
+      // Still `../`: above the repository root, nothing to point at
       if (repoPath.startsWith("../")) return null;
 
       if (isImage) return `${rawURL}/${repoRef}/${repoPath}${suffix}`;
 
-      // `avl/README.md` is a file, `avl` is a folder
+      // Extension means a file: `file` -> blob, `directory` -> tree
       const kind = path.extname(repoPath) ? "blob" : "tree";
 
       return `${repoURL}/${kind}/${repoRef}/${repoPath}${suffix}`;
     };
 
     visit(tree, ["link", "image", "definition", "html"], (node) => {
-      // raw HTML keeps its markup as a string
+      // Raw HTML keeps its markup as a string
       if (node.type === "html") {
         node.value = node.value.replace(HTML_URL, (attribute, name, quote, url) => {
           const rewritten = urlFor(url, name === "src");
@@ -76,6 +77,7 @@ export default function externalRepoLinks({ docsDir, docsPath, repoURL, rawURL, 
         return;
       }
 
+      // `[logo]: ../x.png` is an image only when an `![alt][logo]` reads it
       const isImage =
         node.type === "image" ||
         (node.type === "definition" && imageIdentifiers.has(node.identifier));

--- a/docusaurus/src/remark/external-repo-links.js
+++ b/docusaurus/src/remark/external-repo-links.js
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { visit } from "unist-util-visit";
 
-// Splits a URL into path and `?query#fragment`: `../x.md?plain=1#L3`
+// Splits a URL: `../x.md?plain=1#L3` -> `../x.md` + `?plain=1#L3`
 const URL_PARTS = /^([^?#]*)(.*)$/;
 
 // Matches a URL that does not start from this file: `https://x`, `mailto:x`, `/x`

--- a/docusaurus/src/remark/external-repo-links.js
+++ b/docusaurus/src/remark/external-repo-links.js
@@ -1,7 +1,13 @@
 import path from "node:path";
 import { visit } from "unist-util-visit";
 
-// `href="..."` or `src='...'` in raw HTML: attribute name, quote, URL.
+// `../x.md?plain=1#L3` -> `../x.md` and `?plain=1#L3`
+const URL_PARTS = /^([^?#]*)(.*)$/;
+
+// `https://x`, `mailto:x`, `/x`: addressed from somewhere other than this file
+const ABSOLUTE = /^([a-z][a-z0-9+.-]*:|\/)/i;
+
+// `href="../x"` or `src='../x'`: attribute name, quote, URL
 const HTML_URL = /\b(href|src)=("|')(.*?)\2/g;
 
 /**
@@ -30,38 +36,36 @@ export default function externalRepoLinks({ docsDir, docsPath, repoURL, rawURL, 
 
     const fileDir = path.dirname(path.resolve(file.path));
 
-    // Which definitions an image reads, since the definition itself cannot say.
+    // `![x][logo]` -> `logo`, the definitions an image reads
     const imageIdentifiers = new Set();
     visit(tree, "imageReference", (node) => imageIdentifiers.add(node.identifier));
 
     const urlFor = (url, isImage) => {
       if (!url) return null;
 
-      // The path, then the ?query#fragment carried onto the built URL.
-      const [, target, suffix] = url.match(/^([^?#]*)(.*)$/);
+      const [, target, suffix] = url.match(URL_PARTS);
+      if (!target || ABSOLUTE.test(target)) return null;
 
-      // Relative paths only.
-      if (!target || /^([a-z][a-z0-9+.-]*:|\/)/i.test(target)) return null;
-
+      // in `docs/resources/a.md`, `../../misc/logo.png` -> `../misc/logo.png`
       const fromDocs = path.relative(docsRoot, path.resolve(fileDir, target)).split(path.sep).join("/");
 
-      // Inside the docs folder the site resolves the link itself.
+      // no `../`: inside the docs folder, the site resolves it
       if (!fromDocs.startsWith("../")) return null;
 
-      // Above the repository root nothing can be addressed.
+      // `../misc/logo.png` -> `misc/logo.png`, one more `../` is out of the repository
       const repoPath = path.posix.join(docsPath, fromDocs);
       if (repoPath.startsWith("../")) return null;
 
       if (isImage) return `${rawURL}/${repoRef}/${repoPath}${suffix}`;
 
-      // A path carrying an extension is a file.
+      // `avl/README.md` is a file, `avl` is a folder
       const kind = path.extname(repoPath) ? "blob" : "tree";
 
       return `${repoURL}/${kind}/${repoRef}/${repoPath}${suffix}`;
     };
 
     visit(tree, ["link", "image", "definition", "html"], (node) => {
-      // Raw HTML keeps its markup as a string.
+      // raw HTML keeps its markup as a string
       if (node.type === "html") {
         node.value = node.value.replace(HTML_URL, (attribute, name, quote, url) => {
           const rewritten = urlFor(url, name === "src");

--- a/docusaurus/src/remark/external-repo-links.js
+++ b/docusaurus/src/remark/external-repo-links.js
@@ -36,7 +36,7 @@ export default function externalRepoLinks({ docsDir, docsPath, repoURL, rawURL, 
 
     const fileDir = path.dirname(path.resolve(file.path));
 
-    // `![x][logo]` -> `logo`, the definitions an image reads
+    // Definitions an image reads: `![alt][logo]` + `[logo]: ../x.png` -> `logo`
     const imageIdentifiers = new Set();
     visit(tree, "imageReference", (node) => imageIdentifiers.add(node.identifier));
 

--- a/docusaurus/src/remark/external-repo-links.js
+++ b/docusaurus/src/remark/external-repo-links.js
@@ -1,0 +1,84 @@
+import path from "node:path";
+import { visit } from "unist-util-visit";
+
+// The docs folder is the only part of the monorepo this site holds:
+// scripts/download-docs.sh keeps gno-master/docs and drops the rest. A link
+// climbing out of it therefore has no page to point at, and Docusaurus emits it
+// verbatim, so `../../examples/gno.land/p/nt/avl/v0` ships as
+// `/examples/gno.land/p/nt/avl/v0` and returns 404. Those targets are real
+// files in the monorepo, so the link becomes a URL to the monorepo instead.
+const repoURL = "https://github.com/gnolang/gno";
+
+// The branch download-docs.sh pulls the docs from
+const repoRef = "master";
+
+/**
+ * Rewrites every relative link that resolves outside the docs folder into an
+ * absolute GitHub URL, leaving the markdown sources relative.
+ *
+ * The source file keeps `[avl](../../examples/gno.land/p/nt/avl/v0)`, which
+ * resolves in the monorepo and on GitHub. The built page carries
+ * `https://github.com/gnolang/gno/tree/master/examples/gno.land/p/nt/avl/v0`.
+ *
+ * @param {{docsDir: string}} options docsDir is the folder Docusaurus reads the
+ * docs from, matching the `path` of the docs preset.
+ */
+export default function externalRepoLinks({ docsDir } = {}) {
+  if (!docsDir) {
+    throw new Error("external-repo-links: docsDir is required, and must match the docs preset path");
+  }
+
+  const docsRoot = path.resolve(docsDir);
+
+  return (tree, file) => {
+    if (!file.path) return;
+
+    const fileDir = path.dirname(path.resolve(file.path));
+
+    visit(tree, ["link", "definition"], (node) => {
+      const url = externalRepoURL(node.url, fileDir, docsRoot);
+      if (url) node.url = url;
+    });
+  };
+}
+
+/**
+ * Returns the GitHub URL for a link that leaves the docs folder, or null for
+ * one the site can resolve on its own.
+ */
+function externalRepoURL(url, fileDir, docsDir) {
+  if (!url || !isRelative(url)) return null;
+
+  const [target, suffix] = splitTarget(url);
+  if (!target) return null;
+
+  const segments = path.relative(docsDir, path.resolve(fileDir, target)).split(path.sep);
+
+  // In the monorepo the docs folder sits at the repository root, so a link
+  // climbing one level above it is addressed from that root. One climbing two
+  // levels leaves the repository and has no URL to build.
+  if (segments[0] !== ".." || segments[1] === "..") return null;
+
+  const repoPath = segments.slice(1).join("/");
+  if (!repoPath) return null;
+
+  // A path carrying an extension is a file. GitHub serves both under /tree/,
+  // but /blob/ is the URL a reader recognises.
+  const kind = path.extname(repoPath) ? "blob" : "tree";
+
+  return `${repoURL}/${kind}/${repoRef}/${repoPath}${suffix}`;
+}
+
+// A link is relative when it addresses a path from the file holding it: not a
+// URL, not a protocol-relative or site-absolute path, not a bare fragment.
+function isRelative(url) {
+  return !/^([a-z][a-z0-9+.-]*:|\/\/|\/|#)/i.test(url);
+}
+
+// Splits a link into the path it addresses and the ?query#fragment that rides
+// on the URL built from it
+function splitTarget(url) {
+  const start = url.search(/[?#]/);
+
+  return start === -1 ? [url, ""] : [url.slice(0, start), url.slice(start)];
+}

--- a/docusaurus/src/remark/external-repo-links.js
+++ b/docusaurus/src/remark/external-repo-links.js
@@ -1,13 +1,13 @@
 import path from "node:path";
 import { visit } from "unist-util-visit";
 
-// `../x.md?plain=1#L3` -> `../x.md` and `?plain=1#L3`
+// Splits a URL into path and `?query#fragment`: `../x.md?plain=1#L3`
 const URL_PARTS = /^([^?#]*)(.*)$/;
 
-// `https://x`, `mailto:x`, `/x`: addressed from somewhere other than this file
+// Matches a URL that does not start from this file: `https://x`, `mailto:x`, `/x`
 const ABSOLUTE = /^([a-z][a-z0-9+.-]*:|\/)/i;
 
-// `href="../x"` or `src='../x'`: attribute name, quote, URL
+// Matches one URL attribute of an HTML tag: `href="../x"`, `src='../x'`
 const HTML_URL = /\b(href|src)=("|')(.*?)\2/g;
 
 /**

--- a/docusaurus/src/remark/external-repo-links.js
+++ b/docusaurus/src/remark/external-repo-links.js
@@ -13,6 +13,16 @@ import { visit } from "unist-util-visit";
  * `https://github.com/gnolang/gno/tree/master/examples/gno.land/p/nt/avl/v0`,
  * while the markdown keeps the relative link that resolves in a checkout.
  *
+ * An image needs the file itself rather than the page around it, so it goes to
+ * raw.githubusercontent.com. A `/blob/` URL answers with HTML and renders as a
+ * broken image.
+ *
+ * Register the plugin under `beforeDefaultRemarkPlugins`. Docusaurus resolves
+ * markdown links and reads images from disk before anything in `remarkPlugins`,
+ * so registered there it inherits a warning on every link it is about to fix
+ * and never sees an image at all: the build fails first on `Image ... not
+ * found`.
+ *
  * @param {{docsDir: string, repoURL: string, repoRef: string}} options docsDir
  * matches the `path` of the docs preset, and repoURL and repoRef name the
  * repository and branch the docs were downloaded from.
@@ -23,26 +33,55 @@ export default function externalRepoLinks({ docsDir, repoURL, repoRef } = {}) {
   }
 
   const docsRoot = path.resolve(docsDir);
+  const rawURL = repoURL.replace("https://github.com/", "https://raw.githubusercontent.com/");
 
   return (tree, file) => {
     if (!file.path) return;
 
     const fileDir = path.dirname(path.resolve(file.path));
 
-    visit(tree, ["link", "definition"], (node) => {
-      const repoPath = externalRepoPath(node.url, fileDir, docsRoot, repoRef);
-      if (!repoPath) return;
+    // A definition serves whichever reference names it, and only the reference
+    // says whether the target is read as a page or as an image.
+    const imageIdentifiers = new Set();
+    visit(tree, "imageReference", (node) => imageIdentifiers.add(node.identifier));
 
-      node.url = `${repoURL}/${repoPath}`;
+    const target = (url, isAsset) => {
+      const repoPath = externalRepoPath(url, fileDir, docsRoot);
+      if (!repoPath) return null;
+
+      return isAsset
+        ? `${rawURL}/${repoRef}/${repoPath}`
+        : `${repoURL}/${kindOf(repoPath)}/${repoRef}/${repoPath}`;
+    };
+
+    visit(tree, ["link", "image", "definition", "html"], (node) => {
+      // Raw HTML reaches the page as written, so the attributes are rewritten
+      // in the string itself.
+      if (node.type === "html") {
+        node.value = node.value.replace(
+          /\b(href|src)=("|')(.*?)\2/g,
+          (attribute, name, quote, url) => {
+            const rewritten = target(url, name === "src");
+
+            return rewritten ? `${name}=${quote}${rewritten}${quote}` : attribute;
+          },
+        );
+
+        return;
+      }
+
+      const isAsset = node.type === "image" || imageIdentifiers.has(node.identifier);
+      const rewritten = target(node.url, isAsset);
+      if (rewritten) node.url = rewritten;
     });
   };
 }
 
 /**
- * Returns the `<kind>/<ref>/<path>` a link leaving the docs folder addresses in
- * the monorepo, or null for one the site can resolve on its own.
+ * Returns the `<path>?<query>#<fragment>` a link leaving the docs folder
+ * addresses in the monorepo, or null for one the site can resolve on its own.
  */
-function externalRepoPath(url, fileDir, docsDir, repoRef) {
+function externalRepoPath(url, fileDir, docsDir) {
   if (!url || !isRelative(url)) return null;
 
   const [target, suffix] = splitTarget(url);
@@ -58,11 +97,13 @@ function externalRepoPath(url, fileDir, docsDir, repoRef) {
   const repoPath = segments.slice(1).join("/");
   if (!repoPath) return null;
 
-  // A path carrying an extension is a file. GitHub serves both under /tree/,
-  // but /blob/ is the URL a reader recognises.
-  const kind = path.extname(repoPath) ? "blob" : "tree";
+  return `${repoPath}${suffix}`;
+}
 
-  return `${kind}/${repoRef}/${repoPath}${suffix}`;
+// A path carrying an extension is a file. GitHub serves both under /tree/, but
+// /blob/ is the URL a reader recognises.
+function kindOf(repoPath) {
+  return path.extname(repoPath.replace(/[?#].*$/, "")) ? "blob" : "tree";
 }
 
 // A link is relative when it addresses a path from the file holding it: not a

--- a/docusaurus/src/remark/external-repo-links.js
+++ b/docusaurus/src/remark/external-repo-links.js
@@ -7,25 +7,24 @@ const URL_PARTS = /^([^?#]*)(.*)$/;
 // Matches a URL that is not relative: `https://x`, `mailto:x`, `/x`
 const ABSOLUTE = /^([a-z][a-z0-9+.-]*:|\/)/i;
 
-// Matches one URL attribute of an HTML tag: `href="../x"`, `src='../x'`
-const HTML_URL = /\b(href|src)=("|')(.*?)\2/g;
+// Matches the href of an HTML tag: `href="../x"`, `href='../x'`
+const HTML_HREF = /\bhref=("|')(.*?)\1/g;
 
 /**
- * Rewrites a relative link that resolves outside the docs folder into an
- * absolute URL on the monorepo, in `link`, `image`, `definition` and raw HTML
- * nodes. An image goes to `rawURL`, anything else to `repoURL` under `blob` or
- * `tree`. A link inside the docs folder, an absolute URL and a target above the
- * repository root are left as written.
+ * Rewrites a relative link that resolves outside the docs folder into a GitHub
+ * URL on the monorepo, in `link`, `definition` and raw HTML nodes. A link
+ * inside the docs folder, an absolute URL and a target above the repository
+ * root are left as written.
  *
  * Register under `beforeDefaultRemarkPlugins`.
  *
- * @param {{docsDir: string, docsPath: string, repoURL: string, rawURL: string,
+ * @param {{docsDir: string, docsPath: string, repoURL: string,
  * repoRef: string}} settings all required. docsDir matches the `path` of the
  * docs preset, docsPath is where that folder sits in the repository, and the
  * rest name the repository and branch the docs were downloaded from.
  */
-export default function externalRepoLinks({ docsDir, docsPath, repoURL, rawURL, repoRef } = {}) {
-  for (const [name, value] of Object.entries({ docsDir, docsPath, repoURL, rawURL, repoRef })) {
+export default function externalRepoLinks({ docsDir, docsPath, repoURL, repoRef } = {}) {
+  for (const [name, value] of Object.entries({ docsDir, docsPath, repoURL, repoRef })) {
     if (!value) throw new Error(`external-repo-links: ${name} is required`);
   }
 
@@ -36,10 +35,7 @@ export default function externalRepoLinks({ docsDir, docsPath, repoURL, rawURL, 
 
     const fileDir = path.dirname(path.resolve(file.path));
 
-    const imageIdentifiers = new Set();
-    visit(tree, "imageReference", (node) => imageIdentifiers.add(node.identifier));
-
-    const urlFor = (url, isImage) => {
+    const urlFor = (url) => {
       if (!url) return null;
 
       const [, target, suffix] = url.match(URL_PARTS);
@@ -57,32 +53,25 @@ export default function externalRepoLinks({ docsDir, docsPath, repoURL, rawURL, 
       // Still `../`: above the repository root, nothing to point at
       if (repoPath.startsWith("../")) return null;
 
-      if (isImage) return `${rawURL}/${repoRef}/${repoPath}${suffix}`;
-
       // Extension means a file: `file` -> blob, `directory` -> tree
       const kind = path.extname(repoPath) ? "blob" : "tree";
 
       return `${repoURL}/${kind}/${repoRef}/${repoPath}${suffix}`;
     };
 
-    visit(tree, ["link", "image", "definition", "html"], (node) => {
+    visit(tree, ["link", "definition", "html"], (node) => {
       // Raw HTML keeps its markup as a string
       if (node.type === "html") {
-        node.value = node.value.replace(HTML_URL, (attribute, name, quote, url) => {
-          const rewritten = urlFor(url, name === "src");
+        node.value = node.value.replace(HTML_HREF, (attribute, quote, url) => {
+          const rewritten = urlFor(url);
 
-          return rewritten ? `${name}=${quote}${rewritten}${quote}` : attribute;
+          return rewritten ? `href=${quote}${rewritten}${quote}` : attribute;
         });
 
         return;
       }
 
-      // `[logo]: ../x.png` is an image only when an `![alt][logo]` reads it
-      const isImage =
-        node.type === "image" ||
-        (node.type === "definition" && imageIdentifiers.has(node.identifier));
-
-      const rewritten = urlFor(node.url, isImage);
+      const rewritten = urlFor(node.url);
       if (rewritten) node.url = rewritten;
     });
   };

--- a/docusaurus/src/remark/external-repo-links.js
+++ b/docusaurus/src/remark/external-repo-links.js
@@ -1,28 +1,17 @@
 import path from "node:path";
 import { visit } from "unist-util-visit";
 
-// One URL-carrying attribute of a raw HTML tag, `href="../x"` or `src='../x'`.
-// The captures are the attribute name, the opening quote, and the URL up to the
-// same quote closing it.
+// `href="..."` or `src='...'` in raw HTML: attribute name, quote, URL.
 const HTML_URL = /\b(href|src)=("|')(.*?)\2/g;
 
 /**
- * Rewrites every relative link that resolves outside the docs folder into an
- * absolute GitHub URL, leaving the markdown sources relative.
+ * Rewrites a relative link that resolves outside the docs folder into an
+ * absolute URL on the monorepo, in `link`, `image`, `definition` and raw HTML
+ * nodes. An image goes to `rawURL`, anything else to `repoURL` under `blob` or
+ * `tree`. A link inside the docs folder, an absolute URL and a target above the
+ * repository root are left as written.
  *
- * The docs folder is the only part of the monorepo this site holds, so a link
- * climbing out of it has no page to point at and Docusaurus emits it verbatim:
- * `../../examples/gno.land/p/nt/avl/v0` ships as
- * `/examples/gno.land/p/nt/avl/v0` and returns 404. The built page points at
- * the monorepo instead, while the markdown keeps the relative link that
- * resolves in a checkout.
- *
- * An image goes to `rawURL`, everything else to `repoURL`, because a blob URL
- * answers with HTML and renders as a broken image.
- *
- * Register under `beforeDefaultRemarkPlugins`. Docusaurus resolves markdown
- * links and reads images off disk ahead of `remarkPlugins`, so a plugin
- * registered there runs too late to do either job.
+ * Register under `beforeDefaultRemarkPlugins`.
  *
  * @param {{docsDir: string, repoURL: string, rawURL: string, repoRef: string}}
  * options docsDir matches the `path` of the docs preset, and the rest name the
@@ -40,41 +29,36 @@ export default function externalRepoLinks({ docsDir, repoURL, rawURL, repoRef } 
 
     const fileDir = path.dirname(path.resolve(file.path));
 
-    // A definition serves whichever reference names it, and only the reference
-    // says whether the target is read as a page or as an image.
+    // Which definitions an image reads, since the definition itself cannot say.
     const imageIdentifiers = new Set();
     visit(tree, "imageReference", (node) => imageIdentifiers.add(node.identifier));
 
     const urlFor = (url, isImage) => {
       if (!url) return null;
 
-      // The path the link addresses, then the ?query#fragment that rides on the
-      // URL built from it.
+      // The path, then the ?query#fragment carried onto the built URL.
       const [, target, suffix] = url.match(/^([^?#]*)(.*)$/);
 
-      // Only a path relative to the file holding it can leave the docs folder.
+      // Relative paths only.
       if (!target || /^([a-z][a-z0-9+.-]*:|\/\/|\/)/i.test(target)) return null;
 
       const [up, ...rest] = path.relative(docsRoot, path.resolve(fileDir, target)).split(path.sep);
 
-      // In the monorepo the docs folder sits at the repository root, so a link
-      // climbing one level above it is addressed from that root. One climbing
-      // two levels leaves the repository and has no URL to build.
+      // One level above the docs folder is the repository root, two is outside
+      // the repository.
       if (up !== ".." || !rest.length || rest[0] === "..") return null;
 
       const repoPath = rest.join("/");
       if (isImage) return `${rawURL}/${repoRef}/${repoPath}${suffix}`;
 
-      // A path carrying an extension is a file. GitHub serves both under
-      // /tree/, but /blob/ is the URL a reader recognises.
+      // A path carrying an extension is a file.
       const kind = path.extname(repoPath) ? "blob" : "tree";
 
       return `${repoURL}/${kind}/${repoRef}/${repoPath}${suffix}`;
     };
 
     visit(tree, ["link", "image", "definition", "html"], (node) => {
-      // Raw HTML reaches the page as written, so the attributes are rewritten
-      // in the string itself.
+      // Raw HTML keeps its markup as a string.
       if (node.type === "html") {
         node.value = node.value.replace(HTML_URL, (attribute, name, quote, url) => {
           const rewritten = urlFor(url, name === "src");

--- a/docusaurus/src/remark/external-repo-links.js
+++ b/docusaurus/src/remark/external-repo-links.js
@@ -20,13 +20,13 @@ const HTML_URL = /\b(href|src)=("|')(.*?)\2/g;
  * Register under `beforeDefaultRemarkPlugins`.
  *
  * @param {{docsDir: string, docsPath: string, repoURL: string, rawURL: string,
- * repoRef: string}} options docsDir matches the `path` of the docs preset,
- * docsPath is where that folder sits in the repository, and the rest name the
- * repository and branch the docs were downloaded from.
+ * repoRef: string}} settings all required. docsDir matches the `path` of the
+ * docs preset, docsPath is where that folder sits in the repository, and the
+ * rest name the repository and branch the docs were downloaded from.
  */
 export default function externalRepoLinks({ docsDir, docsPath, repoURL, rawURL, repoRef } = {}) {
-  if (!docsDir || !docsPath || !repoURL || !rawURL || !repoRef) {
-    throw new Error("external-repo-links: every option is required");
+  for (const [name, value] of Object.entries({ docsDir, docsPath, repoURL, rawURL, repoRef })) {
+    if (!value) throw new Error(`external-repo-links: ${name} is required`);
   }
 
   const docsRoot = path.resolve(docsDir);


### PR DESCRIPTION
Six links on the site 404. The deployment holds the monorepo `docs/` folder and nothing else, so a relative link climbing out of it points at a path nothing serves: https://docs.gno.land/resources/gno-packages renders `../../examples/gno.land/p/nt/avl/v0` as `href="/examples/gno.land/p/nt/avl/v0"`.

A remark plugin rewrites those links to the monorepo on GitHub while the page is built. The markdown keeps its relative link, which is what resolves in a checkout and on GitHub.

Images are left alone, they are not supposed to be stored outside the docs directory.

To test:

1. `make dev`
2. Open http://localhost:3000/resources/gno-packages
3. The `avl`, `ufmt` and `seqid` links point at github.com/gnolang/gno

---

Note: I'm not expert in JS, I may have missed some stuff, please let me know if I did!
